### PR TITLE
Preselección de OTHERS y saneamiento de exportación a Excel

### DIFF
--- a/gastos.html
+++ b/gastos.html
@@ -148,11 +148,11 @@
                 <img id="receiptPreview" class="rounded-xl w-full max-h-64 object-contain mx-auto border border-gray-300 hidden" />
                 <div id="extractedData" class="space-y-4 hidden">
                     <select id="expenseCategory" class="input-text">
-                        <option value="" disabled selected>Selecciona una categoría</option>
+                        <option value="" disabled>Selecciona una categoría</option>
                         <option value="OVERSEAS - TRAVEL EXPENSES">OVERSEAS - TRAVEL EXPENSES</option>
                         <option value="LOCAL - TRAVEL EXPENSES">LOCAL - TRAVEL EXPENSES</option>
                         <option value="ENTERTAINMENT">ENTERTAINMENT</option>
-                        <option value="OTHERS">OTHERS</option>
+                        <option value="OTHERS" selected>OTHERS</option>
                     </select>
 
                     <button id="autoFillBtn" class="btn-secondary w-full" disabled>Auto-Rellenar</button>
@@ -340,11 +340,25 @@
                 editingExpenseIndex = null;
                 viewTitle.textContent = 'Añadir Nuevo Gasto';
                 saveBtn.textContent = 'Guardar Gasto';
-                document.getElementById('expenseCategory').value = '';
-                document.getElementById('categoryFields').innerHTML = '';
-                document.getElementById('autoFillBtn').disabled = true;
-                delete document.getElementById('autoFillBtn').dataset.imageMimeType;
-                delete document.getElementById('saveExpenseBtn').dataset.imageData;
+                const categorySelect = document.getElementById('expenseCategory');
+                const fieldsContainer = document.getElementById('categoryFields');
+                const autoFillBtn = document.getElementById('autoFillBtn');
+
+                if (fieldsContainer) {
+                    fieldsContainer.innerHTML = '';
+                }
+
+                if (autoFillBtn) {
+                    autoFillBtn.disabled = false;
+                    delete autoFillBtn.dataset.imageMimeType;
+                }
+
+                if (categorySelect) {
+                    categorySelect.value = 'OTHERS';
+                    categorySelect.dispatchEvent(new Event('change'));
+                }
+
+                delete saveBtn.dataset.imageData;
             }
 
             showView('addExpenseView');
@@ -1087,6 +1101,104 @@ El JSON debe tener este formato exacto:
                 return { startRow, endRow, templateRow };
             }
 
+            function columnLettersToNumber(letters) {
+                if (!letters) return null;
+                let result = 0;
+                for (const char of letters) {
+                    const code = char.charCodeAt(0);
+                    if (code < 65 || code > 90) {
+                        return null;
+                    }
+                    result = (result * 26) + (code - 64);
+                }
+                return result;
+            }
+
+            function parseCellAddress(address) {
+                if (!address) return null;
+                const normalized = address.replace(/\$/g, '').toUpperCase();
+                const match = normalized.match(/^([A-Z]+)(\d+)$/);
+                if (!match) return null;
+                return {
+                    col: columnLettersToNumber(match[1]),
+                    row: parseInt(match[2], 10)
+                };
+            }
+
+            function parseRangeAddress(address) {
+                if (!address) return null;
+                const parts = address.split(':');
+                if (parts.length === 1) {
+                    const cell = parseCellAddress(parts[0]);
+                    return cell ? { start: cell, end: cell } : null;
+                }
+                const start = parseCellAddress(parts[0]);
+                const end = parseCellAddress(parts[1]);
+                if (!start || !end) return null;
+                return { start, end };
+            }
+
+            function resetRowValues(row, templateHeight) {
+                if (!row) return;
+                if (templateHeight !== undefined) {
+                    row.height = templateHeight;
+                }
+                row.hidden = false;
+                row.outlineLevel = 0;
+
+                for (let col = 2; col <= 12; col++) {
+                    const cell = row.getCell(col);
+                    if (cell) {
+                        cell.value = null;
+                    }
+                }
+            }
+
+            function clearCategoryRange(range) {
+                if (!range || !range.startRow || !range.endRow) {
+                    return;
+                }
+
+                const mergesToCheck = [];
+                const rawMerges = ccSheet._merges;
+
+                if (rawMerges) {
+                    if (typeof rawMerges.forEach === 'function') {
+                        rawMerges.forEach((value, key) => {
+                            if (typeof key === 'string') {
+                                mergesToCheck.push(key);
+                            } else if (typeof value === 'string') {
+                                mergesToCheck.push(value);
+                            }
+                        });
+                    } else if (Array.isArray(rawMerges)) {
+                        mergesToCheck.push(...rawMerges);
+                    } else if (typeof rawMerges === 'object') {
+                        Object.keys(rawMerges).forEach(address => mergesToCheck.push(address));
+                    }
+                }
+
+                const templateHeight = range.templateRow ? ccSheet.getRow(range.templateRow).height : undefined;
+                range.templateHeight = templateHeight;
+
+                mergesToCheck.forEach(address => {
+                    const parsed = parseRangeAddress(address);
+                    if (!parsed) return;
+                    if (parsed.end.row < range.startRow || parsed.start.row > range.endRow) return;
+                    if (parsed.end.col < 2 || parsed.start.col > 12) return;
+                    try {
+                        ccSheet.unMergeCells(address);
+                    } catch (error) {
+                        console.warn(`No se pudo descombinar ${address}:`, error);
+                    }
+                });
+
+                for (let rowNum = range.startRow; rowNum <= range.endRow; rowNum++) {
+                    const row = ccSheet.getRow(rowNum);
+                    resetRowValues(row, templateHeight);
+                }
+            }
+
             function rowHasData(row) {
                 const columns = ['B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L'];
                 return columns.some(column => {
@@ -1203,19 +1315,34 @@ El JSON debe tener este formato exacto:
             }
 
             // Procesar cada gasto
+            const categoryRanges = new Map();
+
             for (const expense of project.expenses) {
-                const range = findCategoryRange(expense.category);
-                if (!range.startRow || !range.endRow) {
-                    console.error(`Rango no encontrado para categoría ${expense.category}`);
+                if (!expense || !expense.category) {
                     continue;
+                }
+
+                const category = expense.category;
+                let range = categoryRanges.get(category);
+
+                if (!range) {
+                    range = findCategoryRange(category);
+                    if (!range.startRow || !range.endRow) {
+                        console.error(`Rango no encontrado para categoría ${category}`);
+                        continue;
+                    }
+                    clearCategoryRange(range);
+                    categoryRanges.set(category, range);
                 }
 
                 let rowToUse = findFirstEmptyRow(range.startRow, range.endRow);
                 if (!rowToUse) {
                     rowToUse = insertNewRow(range.endRow, range.templateRow);
+                    range.endRow = rowToUse;
                 }
 
                 const row = ccSheet.getRow(rowToUse);
+                resetRowValues(row, range.templateHeight);
 
                 // Datos comunes
                 row.getCell('B').value = new Date(expense.date);

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -20,6 +20,7 @@ No hay archivos JavaScript o CSS externos: todo el comportamiento y los estilos 
 ### Gestión de gastos
 - Cada proyecto almacena un arreglo `expenses` con los gastos asociados.
 - El formulario de alta se genera dinámicamente en función de la categoría seleccionada (`categoryFields`).
+- Al crear un gasto nuevo la categoría **OTHERS** se carga por defecto y el formulario se despliega automáticamente para agilizar la captura.
 - Se soportan las categorías **OVERSEAS - TRAVEL EXPENSES**, **LOCAL - TRAVEL EXPENSES**, **ENTERTAINMENT** y **OTHERS**, cada una con sus campos particulares.
 - Los gastos se pueden crear y editar; al editar se precargan los datos e imagen previamente guardados.
 - Desde la vista de detalle es posible eliminar un gasto individual desde su tarjeta, previa confirmación, lo que actualiza inmediatamente la lista y el estado persistido.
@@ -52,7 +53,8 @@ No hay archivos JavaScript o CSS externos: todo el comportamiento y los estilos 
 
 ### Exportación a Excel
 - Al pulsar **Descargar Excel** se carga la plantilla `gastos.xlsx`, se localiza la hoja **Corporate Credit Card** y se identifica el bloque correspondiente a cada categoría.
-- El script busca la primera fila vacía dentro del rango de la categoría; si no existe, inserta una nueva fila clonando estilos, formatos y fórmulas del template.
+- Antes de escribir se limpian completamente las filas de datos de la categoría (valores, combinaciones y estado de filas) para evitar que queden textos guía como "Insert line" o celdas fusionadas que oculten información.
+- El script busca la primera fila vacía dentro del rango de la categoría; si no existe, inserta una nueva fila clonando estilos, formatos y fórmulas del template y la prepara antes de insertar los valores.
 - Los campos se escriben en las columnas `B` a `L` según la categoría y se mantiene el formato de fecha cuando procede.
 - Las imágenes de los recibos se insertan en la hoja **LOCAL TE support doc** usando `ExcelJS.Workbook.addImage`, respetando un espaciado mínimo para evitar solapamientos (`rowPadding = 2`, `minimumRowSpacing = 20`).
 - Existe un botón de **Previsualizar Excel** que abre un modal con tablas por categoría (mismo orden y columnas que la exportación) para validar rápidamente que ningún gasto falte antes de descargar la plantilla.

--- a/resumen.md
+++ b/resumen.md
@@ -11,6 +11,8 @@
 - Eliminación de `js/config.js` y `styles.css` al confirmarse que no eran utilizados.
 - Cada tarjeta de gasto permite eliminar el registro tras confirmación, mejorando el control de los proyectos.
 - Se añadió un modal de previsualización del Excel para validar los datos por categoría antes de descargar la plantilla.
+- El formulario de nuevo gasto preselecciona la categoría **OTHERS** y despliega sus campos para acelerar la captura móvil.
+- La exportación a Excel limpia y prepara los rangos antes de escribir, evitando textos residuales y celdas fusionadas que ocultaban información.
 
 ## Próximos pasos sugeridos
 - Implementar un backend que oculte la API key y permita sincronizar los proyectos entre dispositivos.


### PR DESCRIPTION
## Resumen
- preseleccioné la categoría OTHERS al crear un gasto nuevo y desplegué sus campos automáticamente
- limpié rangos de datos y combinaciones en la exportación a Excel antes de inyectar la información y gestioné la inserción de filas adicionales
- actualicé la documentación técnica y el resumen del proyecto con los detalles de los cambios

## Pruebas
- no se añadieron pruebas automatizadas; cambios de interfaz y lógica en el cliente


------
https://chatgpt.com/codex/tasks/task_e_68d922cfd114832d8cab8df51bad78a4