### PR TITLE
Añadir ampliación de recibos en la vista de gastos

### DIFF
--- a/gastos.html
+++ b/gastos.html
@@ -93,6 +93,29 @@
             text-align: center;
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
         }
+        .modal-image-content {
+            background-color: transparent;
+            box-shadow: none;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 1rem;
+            max-width: 95vw;
+        }
+        .modal-image-content img {
+            max-width: 100%;
+            max-height: 80vh;
+            border-radius: 1.5rem;
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+        }
+        .receipt-thumbnail {
+            cursor: zoom-in;
+            transition: transform 0.2s ease;
+        }
+        .receipt-thumbnail:hover {
+            transform: scale(1.02);
+        }
     </style>
 </head>
 <body class="bg-gray-100 text-gray-800">
@@ -186,6 +209,13 @@
         </div>
     </div>
 
+    <div id="imagePreviewModal" class="modal">
+        <div class="modal-content modal-image-content">
+            <img id="modalReceiptImage" src="" alt="Recibo ampliado" />
+            <button id="closeImageModalBtn" class="btn-secondary">Cerrar</button>
+        </div>
+    </div>
+
     <script type="module">
         // Configuración inicial
         const CONFIG = {
@@ -267,6 +297,9 @@
         const excelPreviewModal = document.getElementById('excelPreviewModal');
         const closePreviewBtn = document.getElementById('closePreviewBtn');
         const excelPreviewBody = document.getElementById('excelPreviewBody');
+        const imagePreviewModal = document.getElementById('imagePreviewModal');
+        const modalReceiptImage = document.getElementById('modalReceiptImage');
+        const closeImageModalBtn = document.getElementById('closeImageModalBtn');
 
         function showView(viewName) {
             Object.values(views).forEach(view => view.classList.add('hidden'));
@@ -362,6 +395,19 @@
             }
 
             showView('addExpenseView');
+        }
+
+        function openImageModal(imageSrc) {
+            if (!imageSrc) {
+                return;
+            }
+            modalReceiptImage.src = imageSrc;
+            imagePreviewModal.style.display = 'flex';
+        }
+
+        function closeImageModal() {
+            modalReceiptImage.src = '';
+            imagePreviewModal.style.display = 'none';
         }
 
         function showLoading(show) {
@@ -544,7 +590,7 @@
                 }
 
                 expenseCard.innerHTML = `
-                    ${expense.receiptImage ? `<img src="${expense.receiptImage}" class="rounded-xl w-full max-h-48 object-contain mb-4" />` : ''}
+                    ${expense.receiptImage ? `<img src="${expense.receiptImage}" class="rounded-xl w-full max-h-48 object-contain mb-4 receipt-thumbnail" alt="Recibo del gasto" data-full-image="${expense.receiptImage}" />` : ''}
                     <h3 class="text-lg font-semibold">${expense.details || 'Sin descripción'}</h3>
                     <p class="text-sm font-medium">Fecha: ${expense.date}</p>
                     <p class="text-sm font-medium">Categoría: ${expense.category}</p>
@@ -579,6 +625,13 @@
                 btn.addEventListener('click', (e) => {
                     const expenseIndex = parseInt(e.target.dataset.expenseIndex);
                     deleteExpense(currentProjectId, expenseIndex);
+                });
+            });
+
+            document.querySelectorAll('.receipt-thumbnail').forEach(image => {
+                image.addEventListener('click', () => {
+                    const source = image.dataset.fullImage || image.src;
+                    openImageModal(source);
                 });
             });
         }
@@ -752,9 +805,21 @@
                 closeExcelPreview();
             }
         });
+        closeImageModalBtn.addEventListener('click', closeImageModal);
+        imagePreviewModal.addEventListener('click', (event) => {
+            if (event.target === imagePreviewModal) {
+                closeImageModal();
+            }
+        });
         document.addEventListener('keydown', (event) => {
-            if (event.key === 'Escape' && excelPreviewModal.style.display === 'flex') {
+            if (event.key !== 'Escape') {
+                return;
+            }
+            if (excelPreviewModal.style.display === 'flex') {
                 closeExcelPreview();
+            }
+            if (imagePreviewModal.style.display === 'flex') {
+                closeImageModal();
             }
         });
 

--- a/instrucciones.md
+++ b/instrucciones.md
@@ -24,6 +24,7 @@ No hay archivos JavaScript o CSS externos: todo el comportamiento y los estilos 
 - Se soportan las categorías **OVERSEAS - TRAVEL EXPENSES**, **LOCAL - TRAVEL EXPENSES**, **ENTERTAINMENT** y **OTHERS**, cada una con sus campos particulares.
 - Los gastos se pueden crear y editar; al editar se precargan los datos e imagen previamente guardados.
 - Desde la vista de detalle es posible eliminar un gasto individual desde su tarjeta, previa confirmación, lo que actualiza inmediatamente la lista y el estado persistido.
+- Las miniaturas de los recibos se pueden pulsar para abrir un modal con la imagen en alta resolución; se cierra con el botón dedicado, al hacer clic fuera o con la tecla Escape.
 
 ### Captura de recibos y auto-relleno
 - Los botones **Tomar Foto del Recibo** y **Seleccionar Imagen del Dispositivo** utilizan el `<input type="file" capture="camera">` para obtener la imagen y mostrarla en la vista previa.

--- a/resumen.md
+++ b/resumen.md
@@ -13,6 +13,7 @@
 - Se añadió un modal de previsualización del Excel para validar los datos por categoría antes de descargar la plantilla.
 - El formulario de nuevo gasto preselecciona la categoría **OTHERS** y despliega sus campos para acelerar la captura móvil.
 - La exportación a Excel limpia y prepara los rangos antes de escribir, evitando textos residuales y celdas fusionadas que ocultaban información.
+- Las imágenes de los recibos dentro de cada gasto ahora se amplían en un modal al hacer clic, facilitando su consulta.
 
 ## Próximos pasos sugeridos
 - Implementar un backend que oculte la API key y permita sincronizar los proyectos entre dispositivos.


### PR DESCRIPTION
## Resumen
- Incorporé un modal específico para visualizar los recibos en tamaño grande desde las tarjetas de gasto, con soporte para cerrar al pulsar Escape o fuera de la imagen.
- Ajusté los estilos para destacar las miniaturas como elementos interactivos y documenté la nueva experiencia en `instrucciones.md` y `resumen.md`.

## Pruebas
- No aplica; la aplicación es un documento HTML estático.

------
https://chatgpt.com/codex/tasks/task_e_68d9252e2ff0832dad051038fef343a6